### PR TITLE
Update President Practice  11-20.sql

### DIFF
--- a/President Practice  11-20.sql
+++ b/President Practice  11-20.sql
@@ -1,77 +1,64 @@
--- 11.	Lists names of presidents and wifes and the number of children in every marriage program with more than 5 children.
- 
-select pres_name , spouse_name , nr_children
-from PRES_MARRIAGE
-where nr_children > 5
+-- 11. List presidents, spouses, and number of children in marriages with more than 5 children
+SELECT pres_name, spouse_name, nr_children
+FROM pres_marriage
+WHERE nr_children > 5
+ORDER BY nr_children DESC;
 
--- 12.	Shows the names of the president and their spouses who were married when the president was about 20 years old and the wife was not over 20 years old.
-select pres_name , spouse_name , pr_age, sp_age
-from PRES_MARRIAGE
-where pr_age > 20
-and sp_age <= 20
+-- 12. Show presidents and spouses where the president was about 20 years old and the spouse not over 20
+SELECT pres_name, spouse_name, pr_age, sp_age
+FROM pres_marriage
+WHERE pr_age <= 20
+  AND sp_age <= 20
+ORDER BY pr_age, sp_age;
 
--- 13.Shows the names of presidents and married couples when they are of the same age, sorted by their spouse's age.
- 
-select pres_name , spouse_name , pr_age, sp_age
-from PRES_MARRIAGE
-where pr_age = sp_age
+-- 13. Show presidents and spouses with the same age, sorted by spouse's age
+SELECT pres_name, spouse_name, pr_age, sp_age
+FROM pres_marriage
+WHERE pr_age = sp_age
+ORDER BY sp_age;
 
+-- 14. Show the average age of presidents at marriage
+SELECT AVG(pr_age) AS avg_president_marriage_age
+FROM pres_marriage;
 
+-- 15. Show the average number of children for presidents married after 1900
+SELECT AVG(nr_children) AS avg_children_after_1900
+FROM pres_marriage
+WHERE mar_year > 1900;
 
--- 14.	Shows the average age of a president while married.
- select avg(pr_age) 
-from PRES_MARRIAGE
+-- 16. Show the average number of votes of winners in 20th-century elections
+SELECT AVG(votes) AS avg_winner_votes_20th_century
+FROM election
+WHERE election_year BETWEEN 1901 AND 2000
+  AND winner_loser_indic = 'W';
 
--- 15.	Shows the average number of children whose president married after 1900.
- 
-select avg(nr_children) 
-from PRES_MARRIAGE
-where mar_year > 1900
+-- 17. Show how many distinct elections were held
+SELECT COUNT(DISTINCT election_year) AS total_elections
+FROM election;
 
+-- 18. Number of losing candidates
+SELECT COUNT(DISTINCT candidate) AS total_losers
+FROM election
+WHERE winner_loser_indic = 'L';
 
--- 16.	Shows the average VOTES number of people who won elections in the 20th century.
-select avg(votes)
-from election
-where Election_year >= 1901 
-and Winner_loser_indic = 'W' ;
+-- 18b. List candidates who never won an election
+SELECT DISTINCT candidate
+FROM election 
+WHERE winner_loser_indic = 'L'
+  AND candidate NOT IN (
+      SELECT DISTINCT candidate
+      FROM election
+      WHERE winner_loser_indic = 'W'
+  )
+ORDER BY candidate;
 
--- 17.	Show how many times all the elections were held.
-select count(distinct(election_year))
-from election
+-- 19. Show the number of original states (entered at founding)
+SELECT COUNT(*) AS original_states
+FROM state
+WHERE admin_entered IS NULL;
 
-
--- 18.	Shows the number of losers in the election. (Shows the list of candidates that have never won elections.)
-
--- Result 1: Number of losers in the election
- 
-select count(DISTINCT Candidate)
-from election 
-where Winner_loser_indic = 'L'
-
-
-
-
--- Result 2: Shows the list of candidates that have never won elections.
- 
-select distinct(candidate)
-from election 
-where Winner_loser_indic = 'L'
-and candidate NOT IN (select distinct(candidate)
-	from election 
-where Winner_loser_indic = 'W')
-
-
--- 19.	Shows the number of states that started the United States of America.
- 
-select count(year_entered) 
-from state
-where admin_entered is null ;
-
-
--- 20.	Shows the average life expectancy of presidents from Republicans born after 1850.
- 
-select avg(death_age)
-from president
-where party = 'Republican'
-and Birth_yr > 1850
-
+-- 20. Show average life expectancy of Republican presidents born after 1850
+SELECT AVG(death_age) AS avg_republican_life_expectancy
+FROM president
+WHERE party = 'Republican'
+  AND birth_yr > 1850;


### PR DESCRIPTION
I improved your SQL queries by making them more consistent, readable, and accurate. For query 11, I added an ORDER BY on the number of children in descending order so that larger families appear first. In query 12, I corrected the condition to pr_age <= 20 instead of pr_age > 20, since the requirement was to show presidents who were about 20 years old when married, with spouses not over 20. Query 13 was refined by adding an ORDER BY sp_age so the results are sorted by the spouse’s age as stated in the comment. For queries 14 and 15, I added clear column aliases to make the output more descriptive. Query 16 was adjusted to use BETWEEN 1901 AND 2000 to restrict results strictly to the 20th century, matching the intent. Query 17 was clarified with an alias for the count, making it easier to interpret as the total number of elections. In query 18, I kept the count of losing candidates but also separated the list of candidates who never won elections into a second part (18b) with an explicit ORDER BY candidate for clarity. For query 19, I simplified the count with COUNT(*) since the condition already defines the row set, and gave it a clear alias